### PR TITLE
fix(map): Restore pre-loading with race-condition-free alpha system

### DIFF
--- a/app/src/main/java/com/omiyawaki/osrswiki/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/omiyawaki/osrswiki/ui/map/MapFragment.kt
@@ -101,6 +101,11 @@ class MapFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         L.d("MapFragment: LIFECYCLE: onViewCreated")
+        
+        if (savedInstanceState == null) {
+            view.alpha = 0.0f
+        }
+        
         mapView = binding.mapView
 
         lifecycleScope.launch {
@@ -258,4 +263,13 @@ class MapFragment : Fragment() {
     override fun onStop() { super.onStop(); mapView?.onStop() }
     override fun onSaveInstanceState(outState: Bundle) { super.onSaveInstanceState(outState); mapView?.onSaveInstanceState(outState) }
     override fun onLowMemory() { super.onLowMemory(); mapView?.onLowMemory() }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (hidden) {
+            mapView?.onStop()
+        } else {
+            mapView?.onStart()
+        }
+    }
 }


### PR DESCRIPTION
Restores the pre-loading functionality by reverting to an alpha-based system while fixing the original race condition by moving the initial alpha setting to MapFragment.onViewCreated.